### PR TITLE
add floating point handling to __init__.py

### DIFF
--- a/src/fixr/__init__.py
+++ b/src/fixr/__init__.py
@@ -6,6 +6,11 @@ import io
 
 
 XRIF2NUMPY_DTYPE = {
+    xrif.XRIF_TYPECODE_HALF: np.float16,
+    xrif.XRIF_TYPECODE_FLOAT: np.float32,
+    xrif.XRIF_TYPECODE_DOUBLE: np.float64,
+    xrif.XRIF_TYPECODE_COMPLEX_FLOAT: np.complex64,
+    xrif.XRIF_TYPECODE_COMPLEX_DOUBLE: np.complex128,
     xrif.XRIF_TYPECODE_UINT8: np.uint8,
     xrif.XRIF_TYPECODE_INT8: np.int8,
     xrif.XRIF_TYPECODE_UINT16: np.uint16,

--- a/src/fixr/__init__.py
+++ b/src/fixr/__init__.py
@@ -6,11 +6,6 @@ import io
 
 
 XRIF2NUMPY_DTYPE = {
-    xrif.XRIF_TYPECODE_HALF: np.float16,
-    xrif.XRIF_TYPECODE_FLOAT: np.float32,
-    xrif.XRIF_TYPECODE_DOUBLE: np.float64,
-    xrif.XRIF_TYPECODE_COMPLEX_FLOAT: np.complex64,
-    xrif.XRIF_TYPECODE_COMPLEX_DOUBLE: np.complex128,
     xrif.XRIF_TYPECODE_UINT8: np.uint8,
     xrif.XRIF_TYPECODE_INT8: np.int8,
     xrif.XRIF_TYPECODE_UINT16: np.uint16,
@@ -19,6 +14,11 @@ XRIF2NUMPY_DTYPE = {
     xrif.XRIF_TYPECODE_INT32: np.int32,
     xrif.XRIF_TYPECODE_UINT64: np.uint64,
     xrif.XRIF_TYPECODE_INT64: np.int64,
+    xrif.XRIF_TYPECODE_HALF: np.float16,
+    xrif.XRIF_TYPECODE_FLOAT: np.float32,
+    xrif.XRIF_TYPECODE_DOUBLE: np.float64,
+    xrif.XRIF_TYPECODE_COMPLEX_FLOAT: np.complex64,
+    xrif.XRIF_TYPECODE_COMPLEX_DOUBLE: np.complex128,
 }
 
 class XrifReader:


### PR DESCRIPTION
The wavefront sensor data I am using is storing the frame numbers as floating point values instead of integers. This addition allows to fixr to open and read these files. 